### PR TITLE
docs: fix French description grammar

### DIFF
--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,1 +1,1 @@
-DiagnoStickœur est une application qui permets créer et imprimer des étiquettes autocollantes depuis un navigateur.
+DiagnoStickœur est une application qui permets de créer et imprimer des étiquettes autocollantes depuis un navigateur.


### PR DESCRIPTION
## Problem

- In my last pull request (#34, `docs: update EN/FR descriptions`), I introduced a grammar mistake in the French description: "permets créer" instead of "permets de créer".

## Solution

- Fix the sentence in `doc/DESCRIPTION_fr.md` by adding the missing preposition "de".

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
